### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/joelkariyalil/Context-Aware-Jenkins-Job-Transfers/security/code-scanning/1](https://github.com/joelkariyalil/Context-Aware-Jenkins-Job-Transfers/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow involves checking out the repository and publishing a package to PyPI, it needs `contents: read` for accessing the repository and `packages: write` for publishing the package. No other permissions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
